### PR TITLE
DO-7 2 separate ECR regions for app and base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Deployment Scripts for CI
 
+## 1.0.0 Unreleased
+
+* [DO-7] Allow building the base image in a different region
+
 ## 0.1.0
 
 * [DO-5] Scripts used by all the EB-Docker projects

--- a/bin/deploy
+++ b/bin/deploy
@@ -3,10 +3,10 @@ set -e
 
 export TAG="$(git tag --points-at HEAD | head -n1)"
 [ -n "$TAG" ] || ( >&2 echo No tags to be deployed. && exit 1 )
-[[ "$TAG" != base-* ]] || export BUILDING_BASE_IMAGE=1
+[[ "$TAG" == base-* ]] || export BUILDING_APP_IMAGE=1
 
 cd "$(dirname "$0")"
 
 . ./get-jq
 ./docker-build
-[ -n "$BUILDING_BASE_IMAGE" ] || ./eb-deploy
+[ -z "$BUILDING_APP_IMAGE" ] || ./eb-deploy

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -1,12 +1,22 @@
 #!/bin/bash
 set -e
 
+if [ -n "$BUILDING_APP_IMAGE" ]; then
+  DOCKER_IMAGE="$APP_ECR_IMAGE"
+  ECR_REGION="$APP_ECR_REGION"
+else
+  DOCKER_IMAGE="$BASE_ECR_IMAGE"
+  ECR_REGION="$BASE_ECR_REGION"
+fi
+
+[ -n "$ECR_REGION" ] || ECR_REGION="$AWS_DEFAULT_REGION"
+
 JQ_QUERY='.repositories[] | select(.repositoryUri == "'"$DOCKER_IMAGE"'") | .repositoryName'
-ECR_REPOSITORY_NAME="$(aws ecr describe-repositories | "$JQ_PATH" -r "$JQ_QUERY")"
+ECR_REPOSITORY_NAME="$(aws ecr describe-repositories --region "$ECR_REGION" | "$JQ_PATH" -r "$JQ_QUERY")"
 [ -n "$ECR_REPOSITORY_NAME" ] || ( >&2 echo "Can't find the ECR repository."  && exit 1 )
 
 JQ_QUERY='.imageDetails[] | select(.imageTags[]? | . == "'"$TAG"'")'
-if aws ecr describe-images --repository-name "$ECR_REPOSITORY_NAME" | "$JQ_PATH" -e "$JQ_QUERY"; then
+if aws ecr describe-images --region "$ECR_REGION" --repository-name "$ECR_REPOSITORY_NAME" | "$JQ_PATH" -e "$JQ_QUERY"; then
   echo Skip image building because it has already been built.
   exit
 fi
@@ -14,8 +24,9 @@ fi
 rm -Rf ~/.{rbenv,phpbrew,nvm}
 
 DOCKERFILE=Dockerfile
-[ -z "$BUILDING_BASE_IMAGE" ] || DOCKERFILE=Dockerfile.base
+[ -n "$BUILDING_APP_IMAGE" ] || DOCKERFILE=Dockerfile.base
 
-$(aws ecr get-login)
+$(aws ecr get-login --region "$ECR_REGION")
+[ -z "$BASE_ECR_REGION" ] || $(aws ecr get-login --region "$BASE_ECR_REGION")
 docker build --build-arg VERSION="$TAG" -f "$SEMAPHORE_PROJECT_DIR/$DOCKERFILE" -t "$DOCKER_IMAGE":"$TAG" "$SEMAPHORE_PROJECT_DIR"
 docker push "$DOCKER_IMAGE":"$TAG"


### PR DESCRIPTION
# Why?

In our case, EC2 instances are in Sydney, so it makes sense to have ECR in Sydney.  But Semaphore's boxes are in Germany; and pulling the base image in Sydney from Germany is very slow.

# Testing

I can show you the images build are stored in different ECR repos.