### PR TITLE
DO-40 Provide the script for determining the tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Deployment Scripts for CI
 
+## Unreleased
+
+* [DO-40] Provide the script for determining the deploying tag
+
 ## 1.0.1
 
 * [DO-7] Correct the way it passes the DOCKER_IMAGE variable

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -e
 
-export TAG="$(git tag --points-at HEAD | head -n1)"
-[ -n "$TAG" ] || ( >&2 echo No tags to be deployed. && exit 1 )
-[[ "$TAG" == base-* ]] || export BUILDING_APP_IMAGE=1
+SCRIPT_DIR="$(dirname "$0")"
+
+[ -n "$TAG" ] || . "$SCRIPT_DIR/get-tag"
 
 if [ -n "$BUILDING_APP_IMAGE" ]; then
   DOCKER_IMAGE="$APP_ECR_IMAGE"
@@ -19,7 +19,7 @@ export \
   ECR_REGION \
   DOCKER_IMAGE
 
-cd "$(dirname "$0")"
+cd "$SCRIPT_DIR"
 
 . ./get-jq
 ./docker-build

--- a/bin/get-tag
+++ b/bin/get-tag
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+export TAG="$(git tag --points-at HEAD | head -n1)"
+[ -n "$TAG" ] || ( >&2 echo No tags to be deployed. && exit 1 )
+[[ "$TAG" == base-* ]] || export BUILDING_APP_IMAGE=1


### PR DESCRIPTION
# Why?

So that the projects use this script can access the tag when need to, e.g. to check if there is any pending migration for a particular tag.

# Testing

I will be testing this with Semaphore and our private projects.