### PR TITLE
DO-62 Update the Docker login command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Deployment Scripts for CI
 
+## Unreleased
+
+* [DO-62] Address the backward incompatibility of Docker removing the email flag
+
 ## 1.2.0
 
 * [DO-44] Add ECS deployment support

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -16,7 +16,7 @@ rm -Rf ~/.{rbenv,phpbrew,nvm}
 DOCKERFILE=Dockerfile
 [ -n "$BUILDING_APP_IMAGE" ] || DOCKERFILE=Dockerfile.base
 
-$(aws ecr get-login --region "$ECR_REGION")
+$(aws ecr get-login --no-include-email --region "$ECR_REGION")
 [ -z "$BASE_ECR_REGION" ] || $(aws ecr get-login --region "$BASE_ECR_REGION")
 docker build --build-arg VERSION="$TAG" -f "$SEMAPHORE_PROJECT_DIR/$DOCKERFILE" -t "$DOCKER_IMAGE":"$TAG" "$SEMAPHORE_PROJECT_DIR"
 docker push "$DOCKER_IMAGE":"$TAG"


### PR DESCRIPTION
# Why?

Semaphore updated Docker to 17.06 which removed the `-e` flag.

Please refer to the story for details.