### PR TITLE
DO-72 Automate blue-green deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Deployment Scripts for CI
 
+## Unreleased
+
+* [DO-72] Automate blue/green EB deployment
+
 ## 1.3.1
 
 * [DO-62] Update another Docker login command; missed from 1.3.0

--- a/README.md
+++ b/README.md
@@ -11,44 +11,63 @@ use ECR, ECS and Elastic Beanstalk.
 1. For Elastic Beanstalk:
     1. If the application version doesn't exist in Elastic Beanstalk, create it.
     1. Finally trigger the Elastic Beanstalk deployment.
-    1. If the tag name starts with `base-`, the image will be built and pushed
-       but not deployed.
 1. For ECS:
     1. Create the task revision.
     1. Update the service with the revision.
+1. If the tag name starts with `base-`, the image will be built and pushed but
+   not deployed.
+
+## Experimental blue/green EB deployment automation
+
+This is experimental because Elastic Beanstalk is unstable when this option is
+enabled.
+
+The additional logic is as follows.
+
+1. Before deployment, clone the Elastic Beanstalk environment.
+1. Swap the URLs before the original environment and the cloned environment.
+1. Deploy to the original environment with the `AllAtOnce` option.
+1. Swap back the URL.
+1. Terminate the cloned environment.
 
 ## Environment variables
 
 ### Required variables:
 
 ```
-AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY
-AWS_DEFAULT_REGION
+AWS_ACCESS_KEY_ID=aws-access-key-id
+AWS_SECRET_ACCESS_KEY=aws-secret-access-key
+AWS_DEFAULT_REGION=ap-southeast-2
 
-APP_ECR_IMAGE
-APP_ECR_REGION
+APP_ECR_IMAGE=dkr.ecr.ap-southeast-2.amazonaws.com/my-application
+APP_ECR_REGION=ap-southeast-2
 
 # These 2 are required if you have "base-*" tags, see above.
-BASE_ECR_IMAGE
-BASE_ECR_REGION
+BASE_ECR_IMAGE=dkr.ecr.ap-southeast-2.amazonaws.com/my-application-base
+BASE_ECR_REGION=ap-southeast-2
 
-CI_DEPLOY_TYPE # Either eb or ecs
+CI_DEPLOY_TYPE= # Either eb or ecs
 ```
 
 If you're using Elastic Beanstalk:
 
 ```
-EB_APP_NAME
-EB_ENV_NAME
+EB_APP_NAME=MyApplication
+EB_ENV_NAME=my-application
+```
+
+If you're using the automated blue/green deployment:
+
+```
+ENABLE_BLUE_GREEN_DEPLOY=1
 ```
 
 If you're using ECS:
 
 ```
-ECS_CLUSTER
-ECS_FAMILY
-ECS_SERVICE
+ECS_CLUSTER=production
+ECS_FAMILY=my-application
+ECS_SERVICE=my-application
 ```
 
 ### Optional variables
@@ -56,7 +75,9 @@ ECS_SERVICE
 You may override these if you know what you're doing.
 
 ```
-SEMAPHORE_PROJECT_DIR
-TAG
-JQ_PATH
+SEMAPHORE_PROJECT_DIR=/home/runner/my-application
+TAG=0.1.0
+JQ_PATH=/usr/bin/jq
+EB_WORKER_ENV_NAME=my-application-worker
+CLONE_EB_ENV_NAME_SUFFIX=-clone
 ```

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,9 +1,13 @@
 #!/bin/bash
 set -e
 
-SCRIPT_DIR="$(dirname "$0")"
+pushd "$(dirname "$0")/.."
+export CI_DEPLOY_DIR="$PWD"
+popd
 
-[ -n "$TAG" ] || . "$SCRIPT_DIR/get-tag"
+. "$CI_DEPLOY_DIR/lib/eb/blue-green-deploy"
+
+[ -n "$TAG" ] || . "$CI_DEPLOY_DIR/bin/get-tag"
 
 if [ -n "$BUILDING_APP_IMAGE" ]; then
   DOCKER_IMAGE="$APP_ECR_IMAGE"
@@ -19,9 +23,14 @@ export \
   ECR_REGION \
   DOCKER_IMAGE
 
-cd "$SCRIPT_DIR"
+cd "$CI_DEPLOY_DIR/bin"
 
 . ./get-jq
+
+if [ -n "$ENABLE_BLUE_GREEN_DEPLOY" ] && [ -n "$BUILDING_APP_IMAGE" ]; then
+  ebg_clone
+fi
+
 ./docker-build
 
 [ -n "$BUILDING_APP_IMAGE" ] || exit 0
@@ -30,7 +39,9 @@ cd "$SCRIPT_DIR"
 
 case "$CI_DEPLOY_TYPE" in
   eb)
+    [ -z "$ENABLE_BLUE_GREEN_DEPLOY" ] || ebg_swap_to_clone
     ./eb-deploy
+    [ -z "$ENABLE_BLUE_GREEN_DEPLOY" ] || ebg_swap_to_original
   ;;
   ecs)
     ./ecs-deploy

--- a/bin/eb-deploy
+++ b/bin/eb-deploy
@@ -1,12 +1,9 @@
 #!/bin/bash
 set -e
 
-mkdir -vp \
-  ~/.aws \
-  "$SEMAPHORE_PROJECT_DIR/.elasticbeanstalk"
+. "$CI_DEPLOY_DIR/lib/eb/configure-cli"
 
-envsubst < ../data/aws-config-template > ~/.aws/config
-envsubst < ../data/eb-config-template > "$SEMAPHORE_PROJECT_DIR/.elasticbeanstalk/config.yml"
+eb_configure_cli
 
 cd "$SEMAPHORE_PROJECT_DIR"
 

--- a/lib/eb/blue-green-deploy
+++ b/lib/eb/blue-green-deploy
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+
+. "$CI_DEPLOY_DIR/lib/eb/configure-cli"
+
+ebg_clone() {
+  ebg_fail_if_cloned
+  eb_configure_cli
+
+  pushd "$SEMAPHORE_PROJECT_DIR"
+  eb use "$EB_ENV_NAME"
+  eb clone -nh -n "$(ebg_clone_name)"
+  if ebg_has_worker; then
+    eb use "$EB_WORKER_ENV_NAME"
+    eb clone -nh -n "$(ebg_worker_clone_name)"
+  fi
+  popd
+
+  ebg_rememeber_to_cleanup
+}
+
+ebg_swap_to_clone() {
+  ebg_scale_out_clone
+  ! ebg_has_worker || ebg_scale_out_worker_clone
+  ebg_when_env_ready "$(ebg_clone_name)"
+  ebg_swap
+}
+
+ebg_swap_to_original() {
+  ebg_when_env_ready "$(ebg_worker_clone_name)"
+  if ebg_has_worker; then
+    pushd "$SEMAPHORE_PROJECT_DIR"
+    eb use "$EB_WORKER_ENV_NAME"
+    eb deploy -nh --version "$TAG"
+    popd
+  fi
+  ebg_when_env_ready "$EB_ENV_NAME"
+  ebg_swap
+  ! ebg_has_worker || ebg_when_env_ready "$EB_WORKER_ENV_NAME"
+}
+
+ebg_swap() {
+  pushd "$SEMAPHORE_PROJECT_DIR"
+  eb use "$(ebg_clone_name)"
+  eb swap -n "$EB_ENV_NAME"
+  popd
+}
+
+ebg_has_worker() {
+  [ -n "$EB_WORKER_ENV_NAME" ]
+}
+
+ebg_rememeber_to_cleanup() {
+  trap "ebg_cleanup '$(ebg_cname)'" EXIT
+}
+
+ebg_clone_name() {
+  echo "$EB_ENV_NAME$(ebg_clone_suffix)"
+}
+
+ebg_worker_clone_name() {
+  echo "$EB_WORKER_ENV_NAME$(ebg_clone_suffix)"
+}
+
+ebg_clone_suffix() {
+  local suffix="$CLONE_EB_ENV_NAME_SUFFIX"
+  [ -n "$suffix" ] || suffix=-clone
+  echo "$suffix"
+}
+
+ebg_fail_if_cloned() {
+  ebg_is_cloned || return 0
+  >&2 echo A clone of the environment already exists.
+  exit 1
+}
+
+ebg_is_cloned() {
+  ebg_exists "$(ebg_clone_name)" || ebg_exists "$(ebg_worker_clone_name)"
+}
+
+ebg_exists() {
+  local name="$1"
+
+  aws elasticbeanstalk describe-environments \
+    --application-name "$EB_APP_NAME" |
+  "$JQ_PATH" \
+    -e \
+    --arg name "$name" \
+    '.Environments[] | select(.EnvironmentName == $name and .Status != "Terminated")'
+}
+
+ebg_cname() {
+  aws elasticbeanstalk describe-environments \
+    --application-name "$EB_APP_NAME" \
+    --environment-names "$EB_ENV_NAME" |
+  "$JQ_PATH" -e -r \
+    '[.Environments[] | select(.Status != "Terminated")][0].CNAME'
+}
+
+ebg_cleanup() {
+  local orig_cname="$1"
+
+  if [ "$(ebg_cname)" = "$orig_cname" ]; then
+    ebg_terminate_clone
+    return
+  fi
+
+  >&2 echo 'Deployment failed.  CNAME is pointing to the clone environment.'
+  exit 1
+}
+
+ebg_terminate_clone() {
+  pushd "$SEMAPHORE_PROJECT_DIR"
+  for name in "$(ebg_clone_name)" "$(ebg_worker_clone_name)"; do
+    ebg_exists "$name" || continue
+    eb use "$name"
+    while :; do
+      eb terminate -nh --force || continue
+      break
+    done
+  done
+  popd
+}
+
+ebg_scale_out_clone() {
+  ebg_scale_out "$(ebg_clone_name)"
+}
+
+ebg_scale_out_worker_clone() {
+  ebg_scale_out "$(ebg_worker_clone_name)"
+}
+
+ebg_scale_out() {
+  local name="$1"
+  ebg_when_env_ready "$name"
+
+  local \
+    original_count="$(ebg_instance_count "$EB_ENV_NAME")" \
+    clone_count="$(ebg_instance_count "$name")"
+
+  [ "$original_count" -ne "$clone_count" ] || return 0
+
+  pushd "$SEMAPHORE_PROJECT_DIR"
+  eb use "$name"
+  eb scale "$original_count"
+  popd
+}
+
+ebg_when_env_ready() {
+  local name="$1"
+
+  echo -n Waiting for "$name" to be ready
+  while :; do
+    echo -n .
+    ebg_is_env_ready "$name" > /dev/null || continue
+    break
+  done
+  echo
+}
+
+ebg_is_env_ready() {
+  local name="$1"
+
+  aws elasticbeanstalk describe-environments \
+    --application-name "$EB_APP_NAME" \
+    --environment-name "$name" |
+  "$JQ_PATH" -e \
+    '.Environments[] | select(.Status == "Ready" and .HealthStatus == "Ok")'
+}
+
+ebg_instance_count() {
+  local name="$1"
+
+  aws elasticbeanstalk describe-environment-resources \
+    --environment-id "$(ebg_env_id "$name")" |
+  "$JQ_PATH" -e -r '.EnvironmentResources.Instances | length'
+}
+
+ebg_env_id() {
+  local name="$1"
+
+  aws elasticbeanstalk describe-environments \
+    --application-name "$EB_APP_NAME" \
+    --environment-name "$name" |
+  "$JQ_PATH" -e -r '.Environments[0].EnvironmentId'
+}

--- a/lib/eb/configure-cli
+++ b/lib/eb/configure-cli
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+eb_configure_cli() {
+  mkdir -vp \
+    ~/.aws \
+    "$SEMAPHORE_PROJECT_DIR/.elasticbeanstalk"
+
+  pushd "$CI_DEPLOY_DIR/data"
+  envsubst < aws-config-template > ~/.aws/config
+  envsubst < eb-config-template > "$SEMAPHORE_PROJECT_DIR/.elasticbeanstalk/config.yml"
+  popd
+}


### PR DESCRIPTION
# Why?

Initially, I wanted to use the URL swapping mechanism to speed up deployments.  But EB sometimes has issues when cloning an environment.  I decided to make this an experimental feature and it is disabled by default.