### PR TITLE
Tt 5423 change pact check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Deployment Scripts for CI
 
+## Unreleased
+
+* [TT-5423] Only create pact-versions when the participant is defined
+
 ## 1.5.1
 
 * [TT-5396] Fix Paths / SHA and pact commands

--- a/bin/deploy
+++ b/bin/deploy
@@ -62,7 +62,7 @@ function complete_deployment {
 }
 
 function update_pact_broker {
-  if [ -n "$PACT_BROKER_URL" ]; then
+  if [ -n "$PACT_PARTICIPANT" ]; then
     "$CI_DEPLOY_DIR/bin/get-pact"
     "$CI_DEPLOY_DIR/bin/pact-create-version-tag"
   fi


### PR DESCRIPTION
**WHY**

PACT_BROKER_URL may be defined when we don't actually want to create a pact-version during deployment. 

