### PR TITLE
Tt 5459 add additional build args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Deployment Scripts for CI
 
+## Unreleased
+
+* [TT-5459] Add BUILD_DATE and REVISION as docker build arguments
+
 ## 1.5.2 / 1.5.3
 
 * [TT-5423] Only create pact-versions when the participant is defined

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -20,7 +20,7 @@ $(aws ecr get-login --no-include-email --region "$ECR_REGION")
 [ -z "$BASE_ECR_REGION" ] || $(aws ecr get-login --no-include-email --region "$BASE_ECR_REGION")
 docker build --build-arg VERSION="$TAG" \
   --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` \
-  --build-arg REVISION="$REVISION"
+  --build-arg REVISION="$REVISION" \
   -f "$SEMAPHORE_PROJECT_DIR/$DOCKERFILE" \
   -t "$DOCKER_IMAGE":"$TAG" "$SEMAPHORE_PROJECT_DIR"
 docker push "$DOCKER_IMAGE":"$TAG"

--- a/bin/docker-build
+++ b/bin/docker-build
@@ -18,5 +18,9 @@ DOCKERFILE=Dockerfile
 
 $(aws ecr get-login --no-include-email --region "$ECR_REGION")
 [ -z "$BASE_ECR_REGION" ] || $(aws ecr get-login --no-include-email --region "$BASE_ECR_REGION")
-docker build --build-arg VERSION="$TAG" -f "$SEMAPHORE_PROJECT_DIR/$DOCKERFILE" -t "$DOCKER_IMAGE":"$TAG" "$SEMAPHORE_PROJECT_DIR"
+docker build --build-arg VERSION="$TAG" \
+  --build-arg BUILD_DATE=`date -u +”%Y-%m-%dT%H:%M:%SZ”` \
+  --build-arg REVISION="$REVISION"
+  -f "$SEMAPHORE_PROJECT_DIR/$DOCKERFILE" \
+  -t "$DOCKER_IMAGE":"$TAG" "$SEMAPHORE_PROJECT_DIR"
 docker push "$DOCKER_IMAGE":"$TAG"


### PR DESCRIPTION
WHY

Passes through REVISION and BUILD_DATE to docker so we can add labels to the image to comply with 
https://github.com/opencontainers/image-spec/blob/master/annotations.md