### PR TITLE
TT 6768 tag multiple Pacticipants on deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Deployment Scripts for CI
 
+## Unreleased
+
+* [TT-6768] PACT_PARTICIPANT env can now be comma separated list of participants
+
+
 ## 1.6.0
 
 * [TT-5459] Add BUILD_DATE and REVISION as docker build arguments

--- a/bin/pact-create-version-tag
+++ b/bin/pact-create-version-tag
@@ -1,2 +1,9 @@
 PACT_VERSION="$BRANCH_NAME+$REVISION"
-./pact/bin/pact-broker create-version-tag --pacticipant $PACT_PARTICIPANT --version $PACT_VERSION -t $STAGE --broker-base-url $PACT_BROKER_URL
+IFS=',' read -ra PARTICIPANTS <<< "$PACT_PARTICIPANT"
+
+for PARTICIPANT in "${PARTICIPANTS[@]}"
+do
+  ./pact/bin/pact-broker create-version-tag --pacticipant $PARTICIPANT --version $PACT_VERSION -t $STAGE --broker-base-url $PACT_BROKER_URL
+done
+
+


### PR DESCRIPTION
**WHY**
Need to tag multiple pacticipants on deploy (e.g. Rails API server AND Javascript Client)

**WHAT**
Enabled splitting of `$PACT_PARTICIPANT` on commas (e.g. "provider,consumer") to tag multiple items

**HOW**
On deploy, multiple participants are tagged
Single participants still work