### PR TITLE
Changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Deployment Scripts for CI
 
+## Unreleased
+
+* [TT-7529] Allow creating version tags for multiple stages (i.e. production, edge)
+
 ## 1.8.0
 
 * [TT-6961] Added can-i-deploy wrapper, updated PACT cli tool

--- a/bin/pact-create-version-tag
+++ b/bin/pact-create-version-tag
@@ -1,9 +1,24 @@
+#
+# allows passing multiple tags through via a comma seperated command
+#
+function build_tag_arguments {
+  TAGS_STRING=""
+  IFS=',' read -ra TAGS <<< "$1"
+
+  for tag in "${TAGS[@]}"
+  do
+    TAGS_STRING+="-t $tag "
+  done
+  # Trim the trailing space
+  TAGS_STRING=$(echo $TAGS_STRING | xargs)
+}
+
+build_tag_arguments $STAGE
+
 PACT_VERSION="$BRANCH_NAME+$REVISION"
 IFS=',' read -ra PARTICIPANTS <<< "$PACT_PARTICIPANT"
 
 for PARTICIPANT in "${PARTICIPANTS[@]}"
 do
-  ./pact/bin/pact-broker create-version-tag --pacticipant $PARTICIPANT --version $PACT_VERSION -t $STAGE --broker-base-url $PACT_BROKER_URL
+  ./pact/bin/pact-broker create-version-tag --pacticipant $PARTICIPANT --version $PACT_VERSION --broker-base-url $PACT_BROKER_URL $TAGS_STRING
 done
-
-


### PR DESCRIPTION
### WHY

When deploying into QT production we need to create version tags for both "Edge" and "Production", i've lifted this code from pact-pipe